### PR TITLE
Fix: Correct PHP parse error in files/external/index.php

### DIFF
--- a/files/external/index.php
+++ b/files/external/index.php
@@ -22,13 +22,6 @@
         } else {
             $toastMessage = 'Please enter both username and password.';
         }
-    }
-    // Placeholder for other handlers (registration, password reset) to be added later:
-    // else if (isset($_POST['password_confirm'])) { /* ... registration ... */ }
-    // else if (isset($_POST["resetsubmit"])) { /* ... password reset ... */ }
-    // else if (isset($_POST["resetsubmit1"])) { /* ... password reset ... */ }
-
-    // The generateRandomString function will be added here later if password recovery is integrated into this file.
     } else if (isset($_POST['registersubmit'])) { // Registration attempt
         // Ensure all required fields are present before calling Functions::Register
         if (isset($_POST['username'], $_POST['password'], $_POST['password_confirm'], $_POST['email'])) {


### PR DESCRIPTION
- I resolved a PHP parse error (unmatched '}') by correcting the if/else if conditional structure for POST request handlers (login, registration) at the top of the files/external/index.php.
- I removed extraneous comments between conditional blocks to improve clarity and ensure correct parsing.

This change ensures the PHP code is syntactically valid and that login and registration attempts are correctly routed to their respective handlers.