### PR TITLE
I've enhanced the error logging in the `Functions::Register` method.

### DIFF
--- a/files/classes/Functions.php
+++ b/files/classes/Functions.php
@@ -207,6 +207,7 @@ class Functions
 
           $mysqli->commit();
         } catch (Exception $e) {
+          error_log("Functions::Register Inner Exception: " . $e->getMessage());
           $json['message'] = 'An error login occurred. Please try again later.';
           $mysqli->rollback();
         }
@@ -220,6 +221,7 @@ class Functions
 
         return json_encode($json);
       } catch (Exception $e) {
+        error_log("Functions::Register Exception: " . $e->getMessage());
         $json['type'] = "resultAll";
         $json['message'] = 'An error occurred. Please try again later.';
         $mysqli->rollback();


### PR DESCRIPTION
- I modified the `Register` method in `files/classes/Functions.php`.
- I added `error_log()` calls within the main try-catch block and the nested try-catch block to record specific exception messages (`$e->getMessage()`).

This change aims to capture detailed error information during the registration process to help you diagnose the persistent page reload issue. Debugging logs in `files/external/index.php` remain for comprehensive tracing.