### PR TITLE
Fix: Correct TypeError in footer.php for clan pages

### DIFF
--- a/files/external/includes/footer.php
+++ b/files/external/includes/footer.php
@@ -678,7 +678,7 @@ function message(error, message){
   });
 </script>
 <script type="text/javascript">
-  <?php if (count($array) >= 1) { ?>
+  <?php if (isset($array) && is_array($array) && count($array) >= 1) { ?>
 
   var currentWpClanName = '%clan_name%';
   var currentWpClanId = 0;
@@ -2342,3 +2342,5 @@ $.ajax({
 </html>
 
 
+
+[end of files/external/includes/footer.php]


### PR DESCRIPTION
- Modified files/external/includes/footer.php.
- Changed the conditional check around line 681 from 'count($array)' to 'isset($array) && is_array($array) && count($array) >= 1'.
- This prevents an "Undefined variable $array" warning and a "TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given" when $array is not properly initialized (e.g., on clan pages when there are no pending applications).