### PR TITLE
Fix: Correct syntax error in Functions.php

### DIFF
--- a/files/classes/Functions.php
+++ b/files/classes/Functions.php
@@ -7749,7 +7749,7 @@ function acik_arttirma_lf4_2($bid_credit_lf4_2)
   return null;
 }
 
-  public static function generateCsrfToken()
+function generateCsrfToken()
   {
     if (session_status() == PHP_SESSION_NONE) {
       // It's good practice to ensure session is started, though in many frameworks it already would be.
@@ -7761,14 +7761,14 @@ function acik_arttirma_lf4_2($bid_credit_lf4_2)
     return $token;
   }
 
-  public static function validateCsrfToken($token)
+function validateCsrfToken($token)
   {
     if (empty($_SESSION['csrf_token']) || empty($token)) {
       return false;
     }
     return hash_equals($_SESSION['csrf_token'], $token);
   }
-} // Closing brace for the Functions class
+// Removed extra closing brace that was here.
 
 // LF4 IKINCI
 


### PR DESCRIPTION
The PHP parser reported a syntax error: "unexpected token 'public', expecting end of file" around line 7752 of files/classes/Functions.php.

The error was caused by the functions `generateCsrfToken` and `validateCsrfToken` being defined with `public static` access modifiers while they were outside the scope of the `Functions` class. Additionally, an extraneous closing curly brace `}` was present after these function definitions.

This commit corrects the issue by:
1. Removing the `public static` modifiers from `generateCsrfToken()` and `validateCsrfToken()`, making them global functions.
2. Removing the extraneous closing curly brace.