### PR TITLE
Fix: Correct class structure in Functions.php

### DIFF
--- a/files/classes/Functions.php
+++ b/files/classes/Functions.php
@@ -3693,9 +3693,7 @@ public static function getAmmoId($key) {
   }
     return json_encode($json);
   }
-  
-}
-    
+    // Removed extra closing brace that was here, which prematurely closed the Functions class.
 
   public static function ChangenameData($nameclan)
   {
@@ -7622,6 +7620,26 @@ public static function getAmmoId($key) {
   {
     return self::$upgradeableItemConfig;
   }
+
+  public static function generateCsrfToken()
+  {
+    if (session_status() == PHP_SESSION_NONE) {
+      // It's good practice to ensure session is started, though in many frameworks it already would be.
+      // Depending on the environment, direct session_start() here might be too late or cause issues
+      // if headers are already sent. Assuming session is managed appropriately before this call.
+    }
+    $token = bin2hex(random_bytes(32));
+    $_SESSION['csrf_token'] = $token;
+    return $token;
+  }
+
+  public static function validateCsrfToken($token)
+  {
+    if (empty($_SESSION['csrf_token']) || empty($token)) {
+      return false;
+    }
+    return hash_equals($_SESSION['csrf_token'], $token);
+  }
 	
 }
 
@@ -7749,26 +7767,7 @@ function acik_arttirma_lf4_2($bid_credit_lf4_2)
   return null;
 }
 
-function generateCsrfToken()
-  {
-    if (session_status() == PHP_SESSION_NONE) {
-      // It's good practice to ensure session is started, though in many frameworks it already would be.
-      // Depending on the environment, direct session_start() here might be too late or cause issues
-      // if headers are already sent. Assuming session is managed appropriately before this call.
-    }
-    $token = bin2hex(random_bytes(32));
-    $_SESSION['csrf_token'] = $token;
-    return $token;
-  }
-
-function validateCsrfToken($token)
-  {
-    if (empty($_SESSION['csrf_token']) || empty($token)) {
-      return false;
-    }
-    return hash_equals($_SESSION['csrf_token'], $token);
-  }
-// Removed extra closing brace that was here.
+// generateCsrfToken and validateCsrfToken moved into Functions class.
 
 // LF4 IKINCI
 


### PR DESCRIPTION
The initial "unexpected token 'public'" error, occurring at the definition of `public static function generateCsrfToken()`, was caused by an extraneous closing curly brace `}` located much earlier in the file, specifically after the `changepassword()` method. This extra brace prematurely closed the `Functions` class.

Subsequent attempts to fix this by making `generateCsrfToken` and `validateCsrfToken` global led to "Call to undefined method" errors, confirming these methods belong to the `Functions` class.

This commit resolves these issues by:
1. Removing the extraneous closing curly brace after `changepassword()`.
2. Ensuring `generateCsrfToken()` and `validateCsrfToken()` are correctly defined as `public static` methods within the `Functions` class, near the end of the class definition.

This restores the integrity of the `Functions` class structure, resolving both the parsing and method call errors.